### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kommit.json
+++ b/org.kde.kommit.json
@@ -16,6 +16,16 @@
         "--socket=wayland",
         "--system-talk-name=org.freedesktop.UDisks2"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "/share/qlogging-categories6",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "libssh2",


### PR DESCRIPTION
The installed size reduced from 10.3 MB to 7.2 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.